### PR TITLE
add a function to remove error message when AddCateroryDialog close

### DIFF
--- a/src/MainApp/DrawerContent/AddCategoryButton/AddCategoryDialog.jsx
+++ b/src/MainApp/DrawerContent/AddCategoryButton/AddCategoryDialog.jsx
@@ -70,6 +70,9 @@ export default ({ open, toggleOpen }) => {
   const closeDialog = () => {
     // First call toggle open to hide the dialog
     toggleOpen();
+
+    // Remove all error from Dialog when its get close
+    setErrorMessage('')
     // Wait for 300ms for close animation to finish and
     // then reset the fields to initialCategoryFields for
     // next time


### PR DESCRIPTION
**Bug**
When you try to add a new category without any value it shows an error and when we close it... It does not remove it

**Solution**
Just add a setErrorMessage('') so whenever drower close it just remove all error